### PR TITLE
Add nonce option on dataLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # react-gtm-nonce
 
-> Note
->
-> This package is a fork from https://github.com/alinemorelli/react-gtm. It adds the ability to provide a `nonce` that will be added to the generated `script` attributes, to play well with Content-Security-Policies.
+> This package is a fork from https://github.com/alinemorelli/react-gtm. It adds the ability to provide a `nonce`, that will be added to the generated `script` attributes. This is needed if you
+> are using _Content Security Policy (CSP)_.
+
 
 ### React Google Tag Manager Module (with nonce support)
 
@@ -200,6 +200,26 @@ Look for gtm_auth and gtm_preview
    - https://support.google.com/tagmanager/answer/6311518
    - https://www.simoahava.com/analytics/better-qa-with-google-tag-manager-environments/
 
+
+## Nonce
+
+If you are using _Content Securiy Policy (CSP)_, you can use the `nonce` option that will add a nonce attribute on the generated script tags.
+
+### Example:
+
+```js
+TagManager.initialize({
+    gtmId: 'GTM-000000',
+    nonce: 'some-random-nonce'
+})
+
+...
+
+TagManager.dataLayer({
+    dataLayer: { userId: '001' },
+    nonce: 'some-random-nonce'
+})
+```
 
 |Value|Type|Required|Notes|
 |------|-----|-----|-----|

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -1,9 +1,12 @@
 import Snippets from './Snippets'
 
 const TagManager = {
-  dataScript: function (dataLayer) {
+  dataScript: function (dataLayer, nonce) {
     const script = document.createElement('script')
     script.innerHTML = dataLayer
+    if (nonce) {
+      script.setAttribute('nonce', nonce);
+    }
     return script
   },
   gtm: function (args) {
@@ -24,7 +27,7 @@ const TagManager = {
       return script
     }
 
-    const dataScript = this.dataScript(snippets.dataLayerVar)
+    const dataScript = this.dataScript(snippets.dataLayerVar, args.nonce)
 
     return {
       noScript,
@@ -46,10 +49,10 @@ const TagManager = {
     document.head.insertBefore(gtm.script(), document.head.childNodes[0])
     document.body.insertBefore(gtm.noScript(), document.body.childNodes[0])
   },
-  dataLayer: function ({dataLayer, dataLayerName = 'dataLayer'}) {
+  dataLayer: function ({ dataLayer, dataLayerName = 'dataLayer', nonce }) {
     if (window[dataLayerName]) return window[dataLayerName].push(dataLayer)
     const snippets = Snippets.dataLayer(dataLayer, dataLayerName)
-    const dataScript = this.dataScript(snippets)
+    const dataScript = this.dataScript(snippets, nonce)
     document.head.insertBefore(dataScript, document.head.childNodes[0])
   }
 }


### PR DESCRIPTION
This PR follows https://github.com/memobank/react-gtm-nonce/pull/1, and allows the `nonce` support on the `dataLayer` function as well.